### PR TITLE
:pushpin: Add Netbox v4.1.* compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
-        netbox-version: ["v4.0.10", "v4.0.11"]
+        netbox-version: ["v4.1.0", "master"]
     services:
       redis:
         image: redis

--- a/netbox_aci_plugin/__init__.py
+++ b/netbox_aci_plugin/__init__.py
@@ -19,7 +19,7 @@ class ACIConfig(PluginConfig):
     author_email = __email__
     base_url = "aci"
     min_version = "4.0.0"
-    max_version = "4.0.99"
+    max_version = "4.1.99"
     default_settings = {
         "create_default_aci_tenants": True,
     }


### PR DESCRIPTION
Hello,

Thank you for developing this plugin. We would like to tests it, but we use Netbox v4.1.* versions.

For that, I propose a little patch I think is not complete. I have noted these last points to see with you in order to finalize this PR:

- [x] Review the NetBox changelog for any relevant code changes
- [x] Run automated tests and resolve any errors
- [x] Perform manual testing of UI elements
- [x] Perform manual testing of NetBox branching

If you see any other point to raise, I can update this PR as well.